### PR TITLE
fix: fetch parent customer for customer.discount.* events

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -1029,6 +1029,20 @@ def sync_event_updates(stream_name, is_sub_stream):
         for events_obj in response.auto_paging_iter():
             event_resource_obj = events_obj.data.object
 
+            # customer.discount.* events carry a Discount as data.object, not a
+            # Customer. should_sync_event filters by object type, so the discount
+            # object would be silently dropped. Fetch the parent Customer instead
+            # so the updated discount field is reflected in the customers stream.
+            if stream_name == 'customers' and isinstance(event_resource_obj, stripe.Discount):
+                customer_id = recursive_to_dict(event_resource_obj).get('customer')
+                if not customer_id:
+                    continue
+                event_resource_obj = stripe.Customer.retrieve(
+                    customer_id,
+                    expand=STREAM_TO_EXPAND_FIELDS.get('customers', []),
+                    stripe_account=Context.config.get('account_id'),
+                )
+
             # Check whether we should sync the event based on its created time
             if not should_sync_event(events_obj,
                                      STREAM_TO_TYPE_FILTER[stream_name]['object'],


### PR DESCRIPTION
## Problem

`customer.discount.created`, `customer.discount.updated`, and `customer.discount.deleted` events are silently dropped during incremental event sync.

**Root cause:** `should_sync_event` filters events by the data object's `object` field against `STREAM_TO_TYPE_FILTER['customers']['object'] = ['customer']`. Discount events carry a `Discount` as `data.object` (with `object='discount'`), so the check at line 921 rejects them:

```python
if not event_resource_id or event_resource_dict.get('object') not in object_type:
    return False
```

The event type `customer.*` matches, but the object type filter drops it. Result: any discount applied to an existing customer after initial sync is never captured — the `discount` field stays `NULL` in the landing zone indefinitely.

## Fix

Before `should_sync_event`, detect when the event resource object is a `stripe.Discount` in the `customers` stream. Fetch the parent `Customer` (using the discount's `customer` field) and use that as the event resource instead. The customer object then passes the object type filter and is synced with its current `discount` field populated.

## Testing

Verified against production data: a customer with a `STARTUP-*` coupon applied months after initial sync had `discount = NULL` in the landing zone. After this fix, the next event window covering the `customer.discount.created` event will fetch and sync the full customer object with the discount populated.