### PR TITLE
fix: customer.discount.* events fail sync with invalid expand paths

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -908,11 +908,13 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
                 Context.new_counts[sub_stream_name] += 1
 
 
-def should_sync_event(events_obj, object_type, id_to_created_map):
+def should_sync_event(events_obj, object_type, id_to_created_map, resource_dict=None):
     """Checks to ensure the event's underlying object has an id and that the id_to_created_map
     contains an entry for that id. Returns true the first time an id should be added to the map
-    and when we're looking at an event that is created later than one we've seen before."""
-    event_resource_dict = recursive_to_dict(events_obj.data.object)
+    and when we're looking at an event that is created later than one we've seen before.
+    resource_dict overrides the event's own data.object for the id/object check, for events
+    (e.g. customer.discount.*) whose payload is a child object of the synced resource."""
+    event_resource_dict = resource_dict if resource_dict is not None else recursive_to_dict(events_obj.data.object)
     event_resource_id = event_resource_dict.get('id')
     current_max_created = id_to_created_map.get(event_resource_id)
     event_created = events_obj.created
@@ -1031,22 +1033,31 @@ def sync_event_updates(stream_name, is_sub_stream):
 
             # customer.discount.* events carry a Discount as data.object, not a
             # Customer. should_sync_event filters by object type, so the discount
-            # object would be silently dropped. Fetch the parent Customer instead
-            # so the updated discount field is reflected in the customers stream.
+            # object would be silently dropped. Dedup against the parent customer
+            # id (the same key regular customer.* events use), then fetch the
+            # parent Customer so the updated discount field is reflected in the
+            # customers stream.
             if stream_name == 'customers' and isinstance(event_resource_obj, stripe.Discount):
                 customer_id = recursive_to_dict(event_resource_obj).get('customer')
                 if not customer_id:
                     continue
+                if not should_sync_event(events_obj,
+                                         STREAM_TO_TYPE_FILTER[stream_name]['object'],
+                                         updated_object_timestamps,
+                                         resource_dict={'id': customer_id, 'object': 'customer'}):
+                    continue
+                # The list-endpoint expand paths ('data.*') are invalid on a
+                # single-object retrieve; strip the prefix.
                 event_resource_obj = stripe.Customer.retrieve(
                     customer_id,
-                    expand=STREAM_TO_EXPAND_FIELDS.get('customers', []),
+                    expand=[field[len('data.'):] if field.startswith('data.') else field
+                            for field in STREAM_TO_EXPAND_FIELDS.get('customers', [])],
                     stripe_account=Context.config.get('account_id'),
                 )
-
             # Check whether we should sync the event based on its created time
-            if not should_sync_event(events_obj,
-                                     STREAM_TO_TYPE_FILTER[stream_name]['object'],
-                                     updated_object_timestamps):
+            elif not should_sync_event(events_obj,
+                                       STREAM_TO_TYPE_FILTER[stream_name]['object'],
+                                       updated_object_timestamps):
                 continue
 
             # Syncing an event as its the first time we've seen it or its the most recent version

--- a/tests/unittests/test_customer_discount_events.py
+++ b/tests/unittests/test_customer_discount_events.py
@@ -1,0 +1,139 @@
+import datetime
+import unittest
+from unittest import mock
+
+import stripe
+import tap_stripe
+from tap_stripe import Context, should_sync_event, sync_event_updates
+
+MOCK_NOW = datetime.datetime.strptime("2023-05-10T08:30:50Z", "%Y-%m-%dT%H:%M:%SZ")
+MOCK_NOW_EPOCH = int(MOCK_NOW.timestamp())
+BOOKMARK = MOCK_NOW_EPOCH - 2 * 24 * 60 * 60
+EVENT_CREATED = BOOKMARK + 100
+
+
+class MockEventData:
+    def __init__(self, obj):
+        self.object = obj
+
+
+class MockEvent:
+    def __init__(self, obj, created, event_type):
+        self.data = MockEventData(obj)
+        self.created = created
+        self.type = event_type
+
+
+class MockEventList:
+    def __init__(self, events):
+        self.events = events
+
+    def __len__(self):
+        return len(self.events)
+
+    def auto_paging_iter(self):
+        return iter(self.events)
+
+
+def make_discount_event():
+    discount = stripe.Discount.construct_from(
+        {"id": "di_test", "object": "discount", "customer": "cus_test"}, "sk_test")
+    return MockEvent(discount, EVENT_CREATED, "customer.discount.created")
+
+
+class TestShouldSyncEventResourceDictOverride(unittest.TestCase):
+    """Verify the resource_dict override used for customer.discount.* events."""
+
+    def test_override_passes_object_filter_and_dedups_by_customer_id(self):
+        event = make_discount_event()
+        id_to_created_map = {}
+
+        # Without the override the discount object fails the ['customer'] filter
+        self.assertFalse(should_sync_event(event, ["customer"], id_to_created_map))
+
+        # With the override the event passes and registers the customer id
+        self.assertTrue(should_sync_event(event, ["customer"], id_to_created_map,
+                                          resource_dict={"id": "cus_test", "object": "customer"}))
+        self.assertEqual(id_to_created_map, {"cus_test": EVENT_CREATED})
+
+        # A second event for the same customer at the same time is deduped
+        self.assertFalse(should_sync_event(event, ["customer"], id_to_created_map,
+                                           resource_dict={"id": "cus_test", "object": "customer"}))
+
+
+@mock.patch("tap_stripe.write_bookmark_for_event_updates")
+@mock.patch("tap_stripe.singer.write_record")
+@mock.patch("singer.Transformer.transform", side_effect=lambda rec, *args: rec)
+@mock.patch("tap_stripe.Context.get_catalog_entry",
+            return_value={"metadata": [], "schema": {}})
+@mock.patch("tap_stripe.Context.is_selected", return_value=False)
+@mock.patch("tap_stripe.Context.updated_counts")
+@mock.patch("singer.utils.now", return_value=MOCK_NOW)
+@mock.patch("stripe.Customer.retrieve")
+@mock.patch("stripe.Event.list")
+class TestCustomerDiscountEventUpdates(unittest.TestCase):
+    """Verify customer.discount.* events fetch and sync the parent customer."""
+
+    def setUp(self):
+        Context.config = {"client_secret": "sk_test", "account_id": "acct_test",
+                          "start_date": "2023-04-17T00:00:00"}
+        Context.state = {"bookmarks": {"customers_events": {"updates_created": BOOKMARK}}}
+
+    def test_discount_event_retrieves_customer_with_retrieve_safe_expands(
+            self, mock_event_list, mock_customer_retrieve, mock_now, mock_updated_counts,
+            mock_is_selected, mock_get_catalog_entry, mock_transform,
+            mock_write_record, mock_write_bookmark):
+        mock_event_list.side_effect = [MockEventList([make_discount_event()]), MockEventList([])]
+        mock_customer_retrieve.return_value = stripe.Customer.construct_from(
+            {"id": "cus_test", "object": "customer", "email": "test@example.com"}, "sk_test")
+
+        sync_event_updates("customers", False)
+
+        # The retrieve must use single-object expand paths, not the
+        # list-endpoint 'data.*' paths (Stripe rejects those with
+        # 'This property cannot be expanded (data).')
+        mock_customer_retrieve.assert_called_once_with(
+            "cus_test",
+            expand=["sources", "subscriptions", "tax_ids"],
+            stripe_account="acct_test",
+        )
+
+        # The fetched parent customer is written to the customers stream
+        # (not dropped by the object-type filter)
+        mock_write_record.assert_called_once()
+        stream_name, rec = mock_write_record.call_args[0][:2]
+        self.assertEqual(stream_name, "customers")
+        self.assertEqual(rec["id"], "cus_test")
+        self.assertEqual(rec["updated_by_event_type"], "customer.discount.created")
+        self.assertEqual(rec["updated"], EVENT_CREATED)
+
+    def test_discount_event_without_customer_id_is_skipped(
+            self, mock_event_list, mock_customer_retrieve, mock_now, mock_updated_counts,
+            mock_is_selected, mock_get_catalog_entry, mock_transform,
+            mock_write_record, mock_write_bookmark):
+        discount = stripe.Discount.construct_from(
+            {"id": "di_test", "object": "discount", "customer": None}, "sk_test")
+        event = MockEvent(discount, EVENT_CREATED, "customer.discount.created")
+        mock_event_list.side_effect = [MockEventList([event]), MockEventList([])]
+
+        sync_event_updates("customers", False)
+
+        mock_customer_retrieve.assert_not_called()
+        mock_write_record.assert_not_called()
+
+    def test_duplicate_discount_events_fetch_customer_once(
+            self, mock_event_list, mock_customer_retrieve, mock_now, mock_updated_counts,
+            mock_is_selected, mock_get_catalog_entry, mock_transform,
+            mock_write_record, mock_write_bookmark):
+        mock_event_list.side_effect = [
+            MockEventList([make_discount_event(), make_discount_event()]),
+            MockEventList([]),
+        ]
+        mock_customer_retrieve.return_value = stripe.Customer.construct_from(
+            {"id": "cus_test", "object": "customer"}, "sk_test")
+
+        sync_event_updates("customers", False)
+
+        # Dedup happens before the API call, so the customer is fetched once
+        mock_customer_retrieve.assert_called_once()
+        mock_write_record.assert_called_once()


### PR DESCRIPTION
## Summary

v1.0.6 added handling for `customer.discount.*` events (fetch the parent Customer so discount changes land in the `customers` stream), but it has two bugs that break the sync in production:

1. **Invalid expand paths on retrieve.** `stripe.Customer.retrieve()` was called with the list-endpoint expand paths (`data.sources`, `data.subscriptions`, `data.tax_ids`). The `data.` prefix is only valid on list endpoints; on a single-object retrieve Stripe returns 400 `invalid_request_error: This property cannot be expanded (data).`, which aborts the whole extraction. Fixed by stripping the `data.` prefix for the retrieve call.

2. **Fetched customer was dead code.** After fetching the parent customer, `should_sync_event()` still evaluated the original event payload, whose `data.object` is a Discount (`'discount' not in ['customer']`), so the loop `continue`d and the customer was never written. `should_sync_event()` now takes an optional `resource_dict` override; discount events dedup against the parent customer id (same key space as regular `customer.*` events) **before** the API call, then sync the fetched customer.

## Testing

New unit tests in `tests/unittests/test_customer_discount_events.py` cover:
- retrieve called with `['sources', 'subscriptions', 'tax_ids']` and the fetched customer written with `updated`/`updated_by_event_type`
- discount events without a customer id are skipped
- duplicate discount events for the same customer fetch it once
- `should_sync_event` resource_dict override semantics

`pytest tests/unittests`: 50 passed vs 46 on master, same 18 pre-existing failures (stripe v15 `new_request` removal), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)