### PR TITLE
fix: allow JSON-string tiers in subscription/price embedded schemas

### DIFF
--- a/tap_stripe/schemas/invoice_line_items.json
+++ b/tap_stripe/schemas/invoice_line_items.json
@@ -395,6 +395,7 @@
           "items": {
             "type": [
               "null",
+              "string",
               "object"
             ],
             "properties": {

--- a/tap_stripe/schemas/subscription_items.json
+++ b/tap_stripe/schemas/subscription_items.json
@@ -234,6 +234,7 @@
           "items": {
             "type": [
               "null",
+              "string",
               "object"
             ],
             "properties": {

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -319,7 +319,7 @@
           "items": {
             "type": [
               "null",
-              "integer",
+              "string",
               "object"
             ],
             "properties": {


### PR DESCRIPTION
## Problem

v1.0.8 (#7) added `jsonify_tiers`, which serializes every plan/price `tiers` element to a JSON **string** across all sync paths. That change updated `shared/plan.json` (used by the `plans` stream) to type tier items as `["null", "string", "object"]`, but the **embedded** tier schemas were left unchanged:

| schema file | path | item `type` before |
|---|---|---|
| `subscriptions.json` | `plan.tiers` | `["null", "integer", "object"]` |
| `subscription_items.json` | `price.tiers` | `["null", "object"]` |
| `invoice_line_items.json` | `price.tiers` | `["null", "object"]` |

Because none of those allowed `"string"`, a jsonified tier fails `singer.transform` with `SchemaMismatch: Errors during transform` and aborts the whole tap. It only triggers when a subscription / subscription item / invoice line carrying a **tiered** plan or price is synced (e.g. a legacy `graduated` tiers plan), so it surfaces intermittently rather than on every run.

Reproduced against `singer-python==6.0.1` with the exact embedded schema: a stringified tier raises `SchemaMismatch`; the same input passes once `"string"` is allowed.

## Fix

Add `"string"` to the tier item `type` in the three embedded schemas so they match `shared/plan.json`. Schema-only change; `tests/unittests` baseline is unchanged (18 failures + 3 `new_request` collection errors, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)